### PR TITLE
Fix mobile touch palette & place button sensitivity and update shared-ipc dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "lit-element": "^4.2.1",
         "lit-html": "^3.3.1",
         "marked": "^15.0.12",
-        "shared-ipc": "^1.1.3",
+        "shared-ipc": "^1.2.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -848,7 +848,7 @@
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
 
-    "shared-ipc": ["shared-ipc@1.2.0", "", { "dependencies": { "@rollup/plugin-node-resolve": "^16.0.1", "tslib": "^2.8.1", "typescript": "^5.8.3" } }, "sha512-C4mprRgnlqjNG5uVcZCwf2a29qezcp5Cw2biffvOAKN1eOCWj7XlPOfoCpXDay2nOL5/P1CXLFBhh+GGgCt3PQ=="],
+    "shared-ipc": ["shared-ipc@1.2.1", "", { "dependencies": { "@rollup/plugin-node-resolve": "^16.0.1", "tslib": "^2.8.1", "typescript": "^5.8.3" } }, "sha512-tWvagpULjUf6zI6kRoJv9rkVhftYxxCn3tZL/0YhF8jFEq97fZ5Vs419oYvBxAGxM8yvMZTGxoxnCWgtg+SAAA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "lit-element": "^4.2.1",
         "lit-html": "^3.3.1",
         "marked": "^15.0.12",
-        "shared-ipc": "^1.1.1",
+        "shared-ipc": "^1.1.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -848,7 +848,7 @@
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
 
-    "shared-ipc": ["shared-ipc@1.1.1", "", { "dependencies": { "@rollup/plugin-node-resolve": "^16.0.1", "tslib": "^2.8.1", "typescript": "^5.8.3" } }, "sha512-1lBGPMj1n8ziUeTo92AAZK0iA5wAgPUP3PHKXWNg2vRVegHqqkRbjpZMTJ7sLm3LdM+Ecufmm/GacJq81/tztw=="],
+    "shared-ipc": ["shared-ipc@1.2.0", "", { "dependencies": { "@rollup/plugin-node-resolve": "^16.0.1", "tslib": "^2.8.1", "typescript": "^5.8.3" } }, "sha512-C4mprRgnlqjNG5uVcZCwf2a29qezcp5Cw2biffvOAKN1eOCWj7XlPOfoCpXDay2nOL5/P1CXLFBhh+GGgCt3PQ=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
 		"lit-element": "^4.2.1",
 		"lit-html": "^3.3.1",
 		"marked": "^15.0.12",
-		"shared-ipc": "^1.1.1"
+		"shared-ipc": "^1.2.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
 		"lit-element": "^4.2.1",
 		"lit-html": "^3.3.1",
 		"marked": "^15.0.12",
-		"shared-ipc": "^1.2.0"
+		"shared-ipc": "^1.2.1"
 	}
 }

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -1406,7 +1406,6 @@ document.addEventListener("visibilitychange", () => {
 
 /**
  * @param {Event} e
- * @returns
  */
 function handlePixelPlace(e) {
 	if (!(e instanceof Event) || !e.isTrusted) {
@@ -1443,7 +1442,6 @@ function handlePixelPlace(e) {
 		PEN = -1
 	}
 }
-placeOkButton.addEventListener("touchstart", handlePixelPlace);
 placeOkButton.addEventListener("click", handlePixelPlace);
 /**
  * @param {Event} e
@@ -1470,10 +1468,15 @@ function handlePlaceButtonClicked(e) {
 		runAudio(AUDIOS.invalid)
 	}
 }
-placeButton.addEventListener("touchstart", handlePlaceButtonClicked);
 placeButton.addEventListener("click", handlePlaceButtonClicked);
+/**
+ * @param {Event} e 
+ */
+function handlePlaceCancelClicked(e) {
+	if (!(e instanceof Event) || !e.isTrusted) {
+		return;
+	}
 
-placeCancelButton.addEventListener("click", function(e) {
 	runAudio(AUDIOS.closePalette);
 	canvSelect.style.background = "";
 	palette.style.transform = "translateY(100%)";
@@ -1486,7 +1489,8 @@ placeCancelButton.addEventListener("click", function(e) {
 	canvSelect.style.outline = "";
 	canvSelect.style.boxShadow = "";
 	hideIndicators();
-})
+}
+placeCancelButton.addEventListener("click", handlePlaceCancelClicked);
 
 // Cooldown handling
 /**@type {Timer|null}*/let cooldownInterval = null;
@@ -1690,7 +1694,6 @@ function handleColourClicked(e) {
 	hideIndicators();
 }
 colours.addEventListener("click", handleColourClicked);
-colours.addEventListener("touchstart", handleColourClicked);
 
 /**
  * @param {DataView<ArrayBuffer>} data - Canges packet data


### PR DESCRIPTION
Removes some touchstart handlers and adjust some click handlers for the place button and palette area now that the viewport canvas elements have been separated from the layout HUD, and events no longer interfere to hopefully address over-sensitive palette and colour selections.

This update also bumps shared-ipc to hopefully address some makeDbRequest issues, such as errors causing the moderation menu, linkage and posts menus to not work as expected.