### PR TITLE
POC Clientside spectatorship implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,20 @@
 					</ul>
 				</div>
 			</div>
+			<div id="spectateMenu" class="toast-menu">
+				<div class="toast-header">
+					<h2>Spectate:</h2>
+					<r-close-icon id="spectateCloseButton" class="active"></r-close-icon>
+				</div>
+				<div class="toast-body">
+					<h4>Spectate user:</h4>
+					<label>
+						User ID:
+						<input id="spectateUserIdInput" type="number" placeholder="Enter User ID">
+					</label>
+					<p id="spectateStatusLabel"></p>
+				</div>
+			</div>
 			<div id="overlayMenuOld" noselect class="toast-menu">
 				<div class="toast-header">
 					<h2 title="Make use of a canvas overlay image in order to help yourself better position your pixels" style="display: inline;flex-grow: 1;">Overlay:</h2>

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -1562,21 +1562,21 @@ function handlePixelPlace(e) {
 	// We client-side predict our new cooldown and pixel place the pixel went through
 	// server will (in)validate after
 	setCooldown(COOLDOWN);
-	set(Math.floor(x), Math.floor(y), PEN)
+	set(Math.floor(x), Math.floor(y), PEN);
 
 	// Apply on client-side
 	hideIndicators();
-	placeOkButton.classList.remove("enabled")
-	canvSelect.style.background = ""
-	canvSelect.children[0].style.display = "block"
-	canvSelect.style.outline = ""
-	canvSelect.style.boxShadow = ""
-	palette.style.transform = "translateY(100%)"
-	runAudio(AUDIOS.cooldownStart)
+	placeOkButton.classList.remove("enabled");
+	canvSelect.style.background = "";
+	canvSelect.children[0].style.display = "block";
+	canvSelect.style.outline = "";
+	canvSelect.style.boxShadow = "";
+	palette.style.transform = "translateY(100%)";
+	runAudio(AUDIOS.cooldownStart);
 
 	if (!mobile) {
-		colours.children[PEN].classList.remove("sel")
-		PEN = -1
+		colours.children[PEN].classList.remove("sel");
+		PEN = -1;
 	}
 }
 placeOkButton.addEventListener("click", handlePixelPlace);
@@ -1594,7 +1594,7 @@ function handlePlaceButtonClicked(e) {
 
 		// Persistent colours on mobile platforms
 		if (PEN != -1) {
-			placeOkButton.classList.add("enabled")
+			placeOkButton.classList.add("enabled");
 			canvSelect.style.background = colours.children[PEN].style.background
 			canvSelect.children[0].style.display = 'none'
 			canvSelect.style.outline = '8px white solid'
@@ -2940,19 +2940,20 @@ function startedSpectating(userIntId) {
  */
 function stoppedSpectating(userIntId, reason) {
 	const startState = spectateStartState ?? { x: WIDTH / 2, y: HEIGHT / 2, z: 0 };
-	const transitionDuration = 300;
+	const spectateEndMaxTransition = 2000;
+	const maxTransitionDuration = Math.min(spectateEndMaxTransition, COOLDOWN);
 
 	if (typeof reason === "string" && reason !== "") {
 		alert(`Stopped spectating ${userIntId}: ${reason}`);
 	}
 
 	// Move back to original position before releasing canvas controls
-	moveTo(startState.x, startState.y, startState.z, transitionDuration);
+	moveTo(startState.x, startState.y, startState.z, maxTransitionDuration);
 	setTimeout(() => {
 		spectateUserIdInput.value = "";
 		spectateStatusLabel.textContent = "";
 		setCanvasLocked(false);
-	}, transitionDuration);
+	}, maxTransitionDuration);
 }
 
 

--- a/src/pages/index/index.js
+++ b/src/pages/index/index.js
@@ -714,8 +714,6 @@ function handleUnspectating({ unspectatingIntId, reason }) {
 		spectatingIntId = null;
 	}
 
-	console.log("DEBUG:", unspectatingIntId, reason);
-
 	stoppedSpectating(unspectatingIntId, reason);
 }
 addIpcMessageHandler("handleUnspectating", handleUnspectating);
@@ -1278,10 +1276,10 @@ function pos(newX=x, newY=y, newZ=z) {
 			idPositionDebounce = false;
 			let id = intIdPositions.get(intX + intY * WIDTH);
 			if (id === undefined || id === null) {
-				// Request 16x16 region of pixel placers from server (fine tune if necessary)
+				// Request 15x15 region of pixel placers from server (fine tune if necessary)
 				const placersRadius = 15;
 				const centreX = Math.floor(Math.max(intX - placersRadius / 2, 0));
-				const centreY = Math.floor(Math.max(intY - placersRadius / 2));
+				const centreY = Math.floor(Math.max(intY - placersRadius / 2, 0));
 				const width = Math.min(placersRadius, WIDTH - intX);
 				const height = Math.min(placersRadius, HEIGHT - intY);
 				const position = centreX + centreY * WIDTH;


### PR DESCRIPTION
Referenced by https://github.com/rplacelive/game/issues/389, allows the following of another user as they place pixels around the canvas. While in spectate mode, normal users will not be permitted to place pixels themselves, to prevent abuse (such as following a user around the canvas to harass them). Entering and exiting spectate mode also has a cooldown, and leaving spectate mode resets canvas view to the previous canvas position, or default canvas position, to further ensure it can not be easily misused.


UX is still very clunky and pretty ugly, but core functionality is present and functional. As of currently, this feature is only available for VIP clients.